### PR TITLE
implementar vista de error para manejar fallos en la app de chat GPT

### DIFF
--- a/flutter_chat_app/lib/features/home/presentation/views/view_chat_failure.dart
+++ b/flutter_chat_app/lib/features/home/presentation/views/view_chat_failure.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class ViewChatFailure extends StatelessWidget {
+  final String error;
+
+  const ViewChatFailure({super.key, required this.error});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Icon(Icons.error_outline, color: Colors.red),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            error,
+            style: const TextStyle(color: Colors.red),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/flutter_chat_app/lib/main.dart
+++ b/flutter_chat_app/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_chat_app/features/home/presentation/views/view_chat_failure.dart';
 import 'package:flutter_chat_app/features/home/presentation/views/view_chat_loading.dart';
 import 'features/home/presentation/views/view_chat_initial.dart';
 
@@ -12,6 +13,7 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(title: 'Chat App', home: ChatLoad());
+    return MaterialApp(title: 'Chat App', 
+    home: ViewChatFailure());
   }
 }


### PR DESCRIPTION
- Se crea un widget de error que muestra mensajes claros cuando ocurre una falla.